### PR TITLE
Set Phoenix.Channel log level to :debug

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -1,5 +1,5 @@
 defmodule Absinthe.Phoenix.Channel do
-  use Phoenix.Channel
+  use Phoenix.Channel, log_join: :debug, log_handle_in: :debug
   require Logger
 
   @moduledoc false


### PR DESCRIPTION
I'm not sure how to refactor to allow passing options to Phoenix.Channel, since Absinthe.Phoenix.Channel is compiled once, and then called by the endpoint.